### PR TITLE
feat: add helper functions to project root .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+docker-tags() {
+  local project=$1
+  project=${project:="lewinc/activemq"}
+  local token_uri="https://auth.docker.io/token"
+  local list_uri="https://registry-1.docker.io/v2/$project/tags/list"
+  local scope="scope=repository:${project}:pull"
+  local token=$(curl -Ss "${token_uri}?service=registry.docker.io&${scope}" | jq -r .token)
+  curl -s -H "Accept: application/json" -H "Authorization: Bearer $token" "${list_uri}" | jq -r ".tags[]"
+}
+
+ghcr-tags() {
+  local project=$1
+  project=${project:="quotidian-ennui/docker-activemq"}
+  local ghcr_token=$(curl -s -u"$GITHUB_USER:$(gh auth token)" "https://ghcr.io/token?scope=\"repository:$project:pull\"" | jq --raw-output ".token")
+  curl -s -H "Authorization: Bearer $ghcr_token" "https://ghcr.io/v2/$project/tags/list" | jq --raw-output ".tags[]"
+}
+
+image-tags() {
+  local containerRegistry=$1
+  local repository=$2
+
+  case "$containerRegistry" in
+  quay.io)
+    curl -s "https://quay.io/api/v1/repository/$repository/tag/" | jq -r ".tags[].name"
+    ;;
+  ghcr.io)
+    ghcr-tags $repository
+    ;;
+  *)
+    docker-tags $repository
+    ;;
+  esac
+}
+
+docker-health-check() {
+  local container_id=$1
+  local state=$(docker inspect -f {{.State.Health.Status}} $container_id)
+  while [ "$state" != "healthy" ]; do
+    echo Waiting for ${container_id} to reach 'healthy'
+    sleep 5
+    state=$(docker inspect -f {{.State.Health.Status}} $container_id)
+  done
+  echo ${container_id} is 'healthy'
+}

--- a/localstack/.envrc
+++ b/localstack/.envrc
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+source_up
 source_env_if_exists .envrc.local
 dotenv_if_exists .env
 dotenv_if_exists .secrets

--- a/md2pdf/.envrc
+++ b/md2pdf/.envrc
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+source_up
 source_env_if_exists .envrc.local
 dotenv_if_exists .env
 dotenv_if_exists .secrets

--- a/plantuml/.envrc
+++ b/plantuml/.envrc
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+source_up
 source_env_if_exists .envrc.local
 dotenv_if_exists .env
 dotenv_if_exists .secrets

--- a/pulsar/.envrc
+++ b/pulsar/.envrc
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+source_up
 source_env_if_exists .envrc.local
 dotenv_if_exists .env
 dotenv_if_exists .secrets


### PR DESCRIPTION
## Motivation
Although the functions are useful and they should exist in `~/.bash_functions` or similar. This adds them to project root `.envrc` which useful for those who haven't.

It also ensures that if someone has a variation running it will be overridden with supported version

## Changes

<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged -->
<!-- SQUASH_MERGE_START -->
- add functions from readme to .envrc
- update .envrc files to source_up
- add shebang and let formatter add new line break at end of file
<!-- SQUASH_MERGE_END -->
